### PR TITLE
Bind conf for apiserver in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     - type: bind
       source: /opt/trains/logs
       target: /var/log/trains
+    - type: bind
+      source: /opt/trains/config
+      target: /opt/trains/config
     links:
       - mongo:mongo
       - elasticsearch:elasticsearch


### PR DESCRIPTION
The current docker-compose.yml does not bind /opt/train/conf to the api server, so custom apiserver.conf is not loaded. This patch fixes the issue.