### PR TITLE
Add connection string functionality for MongoDB access

### DIFF
--- a/apiserver/database/__init__.py
+++ b/apiserver/database/__init__.py
@@ -49,18 +49,18 @@ class DatabaseFactory:
         missing = []
         log.info("Initializing database connections")
 
-        override_hostname = first(map(getenv, OVERRIDE_HOST_ENV_KEY), None)
-        if override_hostname:
-            log.info(f"Using override mongodb host {override_hostname}")
-
-        override_port = first(map(getenv, OVERRIDE_PORT_ENV_KEY), None)
-        if override_port:
-            log.info(f"Using override mongodb port {override_port}")
-
         override_connection_string = getenv(OVERRIDE_CONNECTION_STRING_ENV_KEY)
+        override_hostname = first(map(getenv, OVERRIDE_HOST_ENV_KEY), None)
+        override_port = first(map(getenv, OVERRIDE_PORT_ENV_KEY), None)
+
         if override_connection_string:
             log.info(f"Using override mongodb connection string {override_connection_string}")
-
+        else:
+            if override_hostname:
+                log.info(f"Using override mongodb host {override_hostname}")
+            if override_port:
+                log.info(f"Using override mongodb port {override_port}")
+                
         for key, alias in get_items(Database).items():
             if key not in db_entries:
                 missing.append(key)
@@ -68,14 +68,13 @@ class DatabaseFactory:
 
             entry = cls._create_db_entry(alias=alias, settings=db_entries.get(key))
 
-            if override_hostname:
-                entry.host = furl(entry.host).set(host=override_hostname).url
-
-            if override_port:
-                entry.host = furl(entry.host).set(port=override_port).url
-
             if override_connection_string:
                 entry.host = override_connection_string
+            else:
+                if override_hostname:
+                    entry.host = furl(entry.host).set(host=override_hostname).url
+                if override_port:
+                    entry.host = furl(entry.host).set(port=override_port).url
 
             try:
                 entry.validate()

--- a/apiserver/database/__init__.py
+++ b/apiserver/database/__init__.py
@@ -28,6 +28,8 @@ OVERRIDE_PORT_ENV_KEY = (
     "MONGODB_SERVICE_PORT",
 )
 
+OVERRIDE_CONNECTION_STRING_ENV_KEY = "CLEARML_MONGODB_SERVICE_CONNECTION_STRING"
+
 
 class DatabaseEntry(models.Base):
     host = StringField(required=True)
@@ -55,6 +57,10 @@ class DatabaseFactory:
         if override_port:
             log.info(f"Using override mongodb port {override_port}")
 
+        override_connection_string = getenv(OVERRIDE_CONNECTION_STRING_ENV_KEY)
+        if override_connection_string:
+            log.info(f"Using override mongodb connection string {override_connection_string}")
+
         for key, alias in get_items(Database).items():
             if key not in db_entries:
                 missing.append(key)
@@ -67,6 +73,9 @@ class DatabaseFactory:
 
             if override_port:
                 entry.host = furl(entry.host).set(port=override_port).url
+
+            if override_connection_string:
+                entry.host = override_connection_string
 
             try:
                 entry.validate()


### PR DESCRIPTION
This fixes https://github.com/allegroai/clearml-server/issues/86 and will now allow to connect with a MongoDB replicaset consisting of multiple nodes as well.