### PR TITLE
add server root url

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -3,8 +3,7 @@ FROM centos/nodejs-12-centos7 AS webapp
 USER root
 WORKDIR /opt
 
-RUN git clone https://github.com/allegroai/clearml-web.git
-RUN mv clearml-web /opt/open-webapp
+COPY webserver /opt/open-webapp
 COPY --chmod=744 docker/build/internal_files/build_webapp.sh /tmp/internal_files/
 RUN /bin/bash -c '/tmp/internal_files/build_webapp.sh'
 

--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -72,6 +72,28 @@ http {
             add_header Cache-Control 'no-cache';
         }
 
+        location /${NAMESPACE}-clearml {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_pass http://localhost:80;
+            rewrite /${NAMESPACE}-clearml/(.*) /$1  break;
+        }
+
+        location /${NAMESPACE}-clearml/api {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_pass http://localhost:80/api;
+            rewrite /${NAMESPACE}-clearml/api/(.*) /api/$1  break;
+        }
+
+        location /${NAMESPACE}-clearml/files {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_pass http://localhost:80/files;
+            rewrite /${NAMESPACE}-clearml/files/(.*) /files/$1  break;
+            rewrite /${NAMESPACE}-clearml/files /files/  break;
+        }
+
         location /api {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
@@ -84,6 +106,7 @@ http {
             proxy_set_header Host $host;
             proxy_pass ${NGINX_FILESERVER_ADDR};
             rewrite /files/(.*) /$1  break;
+            rewrite /files /  break;
         }
 
         error_page 404 /404.html;

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -49,7 +49,11 @@ EOF
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
 
-    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${NAMESPACE}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
+    envsubst '${NAMESPACE}' < /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
+    cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
+    envsubst '${NAMESPACE}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
 
     #start the server
     /usr/sbin/nginx -g "daemon off;"


### PR DESCRIPTION
The goal is to add support for a web path other than "/". In fact, we are deploying the clearml application per team. Each team can access the solution as follow https://domain_name/<namespace>-clearml
We cannot use the subdomain solution (https://namespace-clearml.domain_name). For this we have added a proxy-pass in the nginx configuration.