### PR TITLE
Allow ClearML to be served with a URL path prefix

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -20,6 +20,7 @@ COPY --from=staging_image /opt/clearml/ /opt/clearml/
 
 COPY --chmod=744 docker/build/internal_files/final_image_preparation.sh /tmp/internal_files/
 COPY docker/build/internal_files/clearml.conf.template /tmp/internal_files/
+COPY docker/build/internal_files/clearml_subpath.conf.template /tmp/internal_files/
 RUN /bin/bash -c '/tmp/internal_files/final_image_preparation.sh'
 
 COPY --from=webapp /opt/open-webapp/build /usr/share/nginx/html

--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -72,26 +72,26 @@ http {
             add_header Cache-Control 'no-cache';
         }
 
-        location /${NAMESPACE}-clearml {
+        location /${CLEARML_SERVER_ROOT_URL} {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_pass http://localhost:80;
-            rewrite /${NAMESPACE}-clearml/(.*) /$1  break;
+            rewrite /${CLEARML_SERVER_ROOT_URL}/(.*) /$1  break;
         }
 
-        location /${NAMESPACE}-clearml/api {
+        location /${CLEARML_SERVER_ROOT_URL}/api {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_pass http://localhost:80/api;
-            rewrite /${NAMESPACE}-clearml/api/(.*) /api/$1  break;
+            rewrite /${CLEARML_SERVER_ROOT_URL}/api/(.*) /api/$1  break;
         }
 
-        location /${NAMESPACE}-clearml/files {
+        location /${CLEARML_SERVER_ROOT_URL}/files {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_pass http://localhost:80/files;
-            rewrite /${NAMESPACE}-clearml/files/(.*) /files/$1  break;
-            rewrite /${NAMESPACE}-clearml/files /files/  break;
+            rewrite /${CLEARML_SERVER_ROOT_URL}/files/(.*) /files/$1  break;
+            rewrite /${CLEARML_SERVER_ROOT_URL}/files /files/  break;
         }
 
         location /api {

--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -72,6 +72,28 @@ http {
             add_header Cache-Control 'no-cache';
         }
 
+        location /${NAMESPACE}-clearml {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_pass http://localhost:80;
+            rewrite /${NAMESPACE}-clearml/(.*) /$1  break;
+        }
+
+        location /${NAMESPACE}-clearml/api {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_pass http://localhost:80/api;
+            rewrite /${NAMESPACE}-clearml/api/(.*) /api/$1  break;
+        }
+
+        location /${NAMESPACE}-clearml/files {
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_pass http://localhost:80/files;
+            rewrite /${NAMESPACE}-clearml/files/(.*) /files/$1  break;
+            rewrite /${NAMESPACE}-clearml/files /files/  break;
+        }
+
         location /api {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
@@ -84,6 +106,7 @@ http {
             proxy_set_header Host $host;
             proxy_pass ${NGINX_FILESERVER_ADDR};
             rewrite /files/(.*) /$1  break;
+            rewrite /files /  break;
         }
 
         error_page 404 /404.html;

--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -72,26 +72,26 @@ http {
             add_header Cache-Control 'no-cache';
         }
 
-        location /${CLEARML_SERVER_ROOT_URL} {
+        location /${CLEARML_SERVER_ROOT_PATH} {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_pass http://localhost:80;
-            rewrite /${CLEARML_SERVER_ROOT_URL}/(.*) /$1  break;
+            rewrite /${CLEARML_SERVER_ROOT_PATH}/(.*) /$1  break;
         }
 
-        location /${CLEARML_SERVER_ROOT_URL}/api {
+        location /${CLEARML_SERVER_ROOT_PATH}/api {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_pass http://localhost:80/api;
-            rewrite /${CLEARML_SERVER_ROOT_URL}/api/(.*) /api/$1  break;
+            rewrite /${CLEARML_SERVER_ROOT_PATH}/api/(.*) /api/$1  break;
         }
 
-        location /${CLEARML_SERVER_ROOT_URL}/files {
+        location /${CLEARML_SERVER_ROOT_PATH}/files {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $host;
             proxy_pass http://localhost:80/files;
-            rewrite /${CLEARML_SERVER_ROOT_URL}/files/(.*) /files/$1  break;
-            rewrite /${CLEARML_SERVER_ROOT_URL}/files /files/  break;
+            rewrite /${CLEARML_SERVER_ROOT_PATH}/files/(.*) /files/$1  break;
+            rewrite /${CLEARML_SERVER_ROOT_PATH}/files /files/  break;
         }
 
         location /api {

--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -65,9 +65,6 @@ http {
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 
-        # Load configuration files for the custom server block.
-        include /etc/nginx/custom.d/*.conf;
-
         location / {
             try_files $uri$args $uri$args/ $uri index.html /index.html;
         }

--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -41,6 +41,7 @@ http {
         server_name  _;
         root         /usr/share/nginx/html;
         proxy_http_version 1.1;
+        client_max_body_size 0;
 
         # comppression
         gzip            on;
@@ -64,34 +65,15 @@ http {
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;
 
+        # Load configuration files for the custom server block.
+        include /etc/nginx/custom.d/*.conf;
+
         location / {
             try_files $uri$args $uri$args/ $uri index.html /index.html;
         }
 
         location /version.json {
             add_header Cache-Control 'no-cache';
-        }
-
-        location /${CLEARML_SERVER_ROOT_PATH} {
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_pass http://localhost:80;
-            rewrite /${CLEARML_SERVER_ROOT_PATH}/(.*) /$1  break;
-        }
-
-        location /${CLEARML_SERVER_ROOT_PATH}/api {
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_pass http://localhost:80/api;
-            rewrite /${CLEARML_SERVER_ROOT_PATH}/api/(.*) /api/$1  break;
-        }
-
-        location /${CLEARML_SERVER_ROOT_PATH}/files {
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Host $host;
-            proxy_pass http://localhost:80/files;
-            rewrite /${CLEARML_SERVER_ROOT_PATH}/files/(.*) /files/$1  break;
-            rewrite /${CLEARML_SERVER_ROOT_PATH}/files /files/  break;
         }
 
         location /api {
@@ -106,7 +88,6 @@ http {
             proxy_set_header Host $host;
             proxy_pass ${NGINX_FILESERVER_ADDR};
             rewrite /files/(.*) /$1  break;
-            rewrite /files /  break;
         }
 
         error_page 404 /404.html;

--- a/docker/build/internal_files/clearml_subpath.conf.template
+++ b/docker/build/internal_files/clearml_subpath.conf.template
@@ -1,0 +1,21 @@
+location /${CLEARML_SERVER_SUB_PATH} {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_pass http://localhost:80;
+    rewrite /${CLEARML_SERVER_SUB_PATH}/(.*) /$1  break;
+}
+
+location /${CLEARML_SERVER_SUB_PATH}/api {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_pass http://localhost:80/api;
+    rewrite /${CLEARML_SERVER_SUB_PATH}/api/(.*) /api/$1  break;
+}
+
+location /${CLEARML_SERVER_SUB_PATH}/files {
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header Host $host;
+    proxy_pass http://localhost:80/files;
+    rewrite /${CLEARML_SERVER_SUB_PATH}/files/(.*) /files/$1  break;
+    rewrite /${CLEARML_SERVER_SUB_PATH}/files /files/  break;
+}

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -49,7 +49,11 @@ EOF
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
 
-    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${NAMESPACE}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
+    envsubst '${NAMESPACE}' < /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
+    cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
+    envsubst '${NAMESPACE}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
 
     #start the server
     /usr/sbin/nginx -g "daemon off;"

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -48,12 +48,9 @@ EOF
 
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
+    export CLEARML_SERVER_ROOT_URL=${CLEARML_SERVER_ROOT_URL:-ROOT}
 
-    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${NAMESPACE}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
-    cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
-    envsubst '${NAMESPACE}' < /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
-    cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
-    envsubst '${NAMESPACE}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
+    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${CLEARML_SERVER_ROOT_URL}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
 
     #start the server
     /usr/sbin/nginx -g "daemon off;"

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -48,9 +48,9 @@ EOF
 
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
-    export CLEARML_SERVER_ROOT_URL=${CLEARML_SERVER_ROOT_URL:-ROOT}
+    export CLEARML_SERVER_ROOT_PATH=${CLEARML_SERVER_ROOT_PATH:-ROOT}
 
-    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${CLEARML_SERVER_ROOT_URL}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${CLEARML_SERVER_ROOT_PATH}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
 
     #start the server
     /usr/sbin/nginx -g "daemon off;"

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -56,9 +56,7 @@ EOF
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/custom.d/clearml_subpath.conf
       cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
-      sed 's/BASE_HREF/\/'${CLEARML_SERVER_SUB_PATH}'\//' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
-    else
-      sed 's/BASE_HREF/\//' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
+      sed 's/href="\/"/href="\/'${CLEARML_SERVER_SUB_PATH}'\/"/' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
     fi
 
     #start the server

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -48,9 +48,18 @@ EOF
 
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
-    export CLEARML_SERVER_ROOT_PATH=${CLEARML_SERVER_ROOT_PATH:-ROOT}
+    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
 
-    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR} ${CLEARML_SERVER_ROOT_PATH}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
+    mkdir -p /etc/nginx/custom.d/
+    if [[ -n "${CLEARML_SERVER_SUB_PATH}" ]]; then
+      envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/custom.d/clearml_subpath.conf
+      cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
+      envsubst '${CLEARML_SERVER_SUB_PATH}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
+      sed 's/BASE_HREF/\/'${CLEARML_SERVER_SUB_PATH}'\//' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
+    else
+      sed 's/BASE_HREF/\//' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
+    fi
 
     #start the server
     /usr/sbin/nginx -g "daemon off;"

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -50,11 +50,11 @@ EOF
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
     envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
 
-    cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
     if [[ -n "${CLEARML_SERVER_SUB_PATH}" ]]; then
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/default.d/clearml_subpath.conf
       cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
+      cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
       sed 's/href="\/"/href="\/'${CLEARML_SERVER_SUB_PATH}'\/"/' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html
     fi
 

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -51,9 +51,8 @@ EOF
     envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
 
     cp /usr/share/nginx/html/index.html /usr/share/nginx/html/index.html.origin
-    mkdir -p /etc/nginx/custom.d/
     if [[ -n "${CLEARML_SERVER_SUB_PATH}" ]]; then
-      envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/custom.d/clearml_subpath.conf
+      envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/default.d/clearml_subpath.conf
       cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js
       sed 's/href="\/"/href="\/'${CLEARML_SERVER_SUB_PATH}'\/"/' /usr/share/nginx/html/index.html.origin > /usr/share/nginx/html/index.html

--- a/docker/build/internal_files/final_image_preparation.sh
+++ b/docker/build/internal_files/final_image_preparation.sh
@@ -15,4 +15,5 @@ ln -s /dev/stdout /var/log/nginx/access.log
 ln -s /dev/stderr /var/log/nginx/error.log
 mv /etc/nginx/nginx.conf /etc/nginx/nginx.conf.orig
 mv /tmp/internal_files/clearml.conf.template /etc/nginx/clearml.conf.template
+mv /tmp/internal_files/clearml_subpath.conf.template /etc/nginx/clearml_subpath.conf.template
 yum clean all

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -108,6 +108,8 @@ services:
     command:
     - webserver
     container_name: clearml-webserver
+    # environment:
+    #  CLEARML_SERVER_SUB_PATH : clearml-web # Allow Clearml to be served with a URL path prefix.
     image: allegroai/clearml:latest
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
The goal is to add support for a web path other than "/". In fact, we are deploying the clearml application per team. Each team can access the solution as follow https://domain_name/<namespace>-clearml
We cannot use the subdomain solution (https://namespace-clearml.domain_name). For this we have added a proxy-pass in the nginx configuration.