### PR TITLE
Ensure agent-services waits for API server to be ready

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -152,6 +152,8 @@ services:
       - /opt/clearml/agent:/root/.clearml
     depends_on:
       - apiserver
+    entrypoint: >
+      bash -c "curl --retry 10 --retry-delay 10 --retry-connrefused 'http://apiserver:8008/debug.ping' && /usr/agent/entrypoint.sh"
 
 networks:
   backend:


### PR DESCRIPTION
As discussed in #113, this change ensures that the API server is ready before the `agent-services` container starts. This stops it from failing immediately and stopping.