### PR TITLE
Add env switch to disable nginx ipv6 bind

### DIFF
--- a/docker/build/internal_files/clearml.conf.template
+++ b/docker/build/internal_files/clearml.conf.template
@@ -37,7 +37,7 @@ http {
 
     server {
         listen       80 default_server;
-        listen       [::]:80 default_server;
+        ${COMMENT_IPV6_LISTEN}listen       [::]:80 default_server;
         server_name  _;
         root         /usr/share/nginx/html;
         proxy_http_version 1.1;

--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -48,7 +48,8 @@ EOF
 
     export NGINX_APISERVER_ADDR=${NGINX_APISERVER_ADDRESS:-http://apiserver:8008}
     export NGINX_FILESERVER_ADDR=${NGINX_FILESERVER_ADDRESS:-http://fileserver:8081}
-    envsubst '${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
+    COMMENT_IPV6_LISTEN=$([ "$DISABLE_NGINX_IPV6" = "true" ] && echo "#" || echo "") \
+     envsubst '${COMMENT_IPV6_LISTEN} ${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/nginx.conf
 
     if [[ -n "${CLEARML_SERVER_SUB_PATH}" ]]; then
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/default.d/clearml_subpath.conf


### PR DESCRIPTION
Currently, when trying to use the docker image to deploy the web fronted on a system/cluster without IPV6, the nginx server fails with the error message: `nginx: [emerg] socket() [::]:80 failed (97: Address family not supported by protocol)`.
To fix this, this PR provides an environment variable to switch off the listen directive for IPV6.