### PR TITLE
fix(entrypoint): fix handling of the subpaths with nginx templating

### DIFF
--- a/docker/build/internal_files/entrypoint.sh
+++ b/docker/build/internal_files/entrypoint.sh
@@ -52,6 +52,7 @@ EOF
      envsubst '${COMMENT_IPV6_LISTEN} ${NGINX_APISERVER_ADDR} ${NGINX_FILESERVER_ADDR}' < /etc/nginx/clearml.conf.template > /etc/nginx/sites-enabled/default
 
     if [[ -n "${CLEARML_SERVER_SUB_PATH}" ]]; then
+      mkdir -p /etc/nginx/default.d/
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /etc/nginx/clearml_subpath.conf.template > /etc/nginx/default.d/clearml_subpath.conf
       cp /usr/share/nginx/html/env.js /usr/share/nginx/html/env.js.origin
       envsubst '${CLEARML_SERVER_SUB_PATH}' < /usr/share/nginx/html/env.js.origin > /usr/share/nginx/html/env.js


### PR DESCRIPTION
This PR Is to fix the entrypoint of the docker image, because it fails when trying to use the CLEARML_SERVER_SUB_PATH en variable. The directory default.d no longer exists in the nginx image used by the Dockerfile.
