### PR TITLE
Add variant and metrics to events_plot mapping

### DIFF
--- a/apiserver/elastic/mappings/events/events_plot.json
+++ b/apiserver/elastic/mappings/events/events_plot.json
@@ -9,6 +9,12 @@
       },
       "plot_data": {
         "type": "binary"
+      },
+      "variant": { 
+        "type": "keyword"
+      },
+      "metric": { 
+        "type": "keyword"
       }
     }
   }


### PR DESCRIPTION
We had some issues with duplicated plots in our ClearML deployment.

The reason was that Elastiscearch infered `text` for these fields and we do an aggregation query.

This PR sets them explicity to type `keyword`, which should make it more stable given that field inference works slightly different in different Elasticsearch versions.