### PR TITLE
Fix elasticsearch memory requirements

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -60,6 +60,10 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    deploy:
+      resources:
+        limits:
+          memory: 1gb
     image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
Elasticsearch service silently terminates because of OOM. Add memory requirements according to the official page "Install Elasticsearch with Docker":
```docker run -m 1GB ...```