### PR TITLE
Sync apiserver.conf notes with docs

### DIFF
--- a/apiserver/config/default/apiserver.conf
+++ b/apiserver/config/default/apiserver.conf
@@ -86,7 +86,7 @@
 #        }
 
 #        # A list of fixed users
-#        # Note: password may be bcrypt-hashed (generate using `python -c 'import bcrypt; print(bcrypt.hashpw("password", bcrypt.gensalt()))'`)
+#        # Note: password may be base64-encoded bcrypt-hashed (generate using `python -c 'import bcrypt,base64; print(base64.b64encode(bcrypt.hashpw("password".encode(), bcrypt.gensalt())))'`)
 #        fixed_users {
 #            enabled: true
 #            pass_hashed: false


### PR DESCRIPTION
The existing note in default `apiserver.conf` includes a command to generate a bcrypt-hashed password, but it omits the base64 encoding step:
```
python -c 'import bcrypt; print(bcrypt.hashpw("password", bcrypt.gensalt()))'
```
This may be misleading for new users, since the server expects base64-encoded hashes.

The note is updated to include the correct code snippet with base64 encoding, as shown in the  [documentation](https://clear.ml/docs/latest/docs/deploying_clearml/clearml_server_config#using-hashed-passwords):
```
python -c 'import bcrypt,base64; print(base64.b64encode(bcrypt.hashpw("password".encode(), bcrypt.gensalt())))'
```